### PR TITLE
Correct ACM to *certificate* manager

### DIFF
--- a/docs/aws_acm.md
+++ b/docs/aws_acm.md
@@ -1,4 +1,4 @@
-# AWS Credential Manager (ACM)
+# AWS Certificate Manager (ACM)
 
 This page lists various activites that may be necessary to perform when leveraging Zappa
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,7 @@ pages:
     - 'Adventures in Networking' : 'aws_network.md'
     - 'Creating an RDS Database' : 'aws_database.md'
     - 'Working with Route53' : 'aws_route53.md'
-    - 'AWS Credential Manager (ACM)' : 'aws_acm.md'
+    - 'AWS Certificate Manager (ACM)' : 'aws_acm.md'
   - Additional: 'additional.md'
 theme: 'material'
 extra:


### PR DESCRIPTION
A few places referred to ACM as _AWS **credential** manager_ instead of _AWS **certificate** manager_. (https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)