### PR TITLE
Change info command to status

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -197,7 +197,7 @@ zappashell> source ve/bin/activate
 All zappa commands can be used to deploy your project:
 
 ```sh
-(ve) zappashell> zappa info dev
+(ve) zappashell> zappa status dev
 ```
 
 


### PR DESCRIPTION
info doesn't seem to be a valid zappa command in the latest version. Changed to status since I figured that's the best replacement